### PR TITLE
Add training and prediction scripts with model serialization

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+import argparse
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "src"))
+
+from hurdle_forecast.model import HurdleForecastModel
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Load trained model and run predictions on test data.")
+    ap.add_argument("--model", required=True, help="Path to pickled model")
+    ap.add_argument("--test_dir", required=True, help="Directory containing TEST_*.csv files")
+    ap.add_argument("--out_dir", required=True, help="Directory to write predictions")
+    ap.add_argument("--sample_submission", default=None, help="Optional sample submission to fill")
+    args = ap.parse_args()
+
+    model = HurdleForecastModel.load(args.model)
+    model.predict_dir(args.test_dir, args.out_dir, sample_submission=args.sample_submission)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/hurdle_forecast/model.py
+++ b/src/hurdle_forecast/model.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Optional
+import os
+import pickle
+import pandas as pd
+import numpy as np
+
+from .config import Config
+from .data import cutoff_train, future_dates
+from .classifier import beta_smooth_probs, logistic_global_calendar
+from .intensity import forecast_intensity
+from .combine import combine_expectation, fill_submission_skeleton
+
+
+def _prepare_train(cfg: Config) -> pd.DataFrame:
+    """Load and preprocess the training CSV similar to `load_datasets`."""
+    train = pd.read_csv(cfg.train_csv)
+    series_cols = cfg.series_cols
+    date_col = cfg.date_col
+    target_col = cfg.target_col
+    missing = [c for c in [*series_cols, date_col, target_col] if c not in train.columns]
+    if missing:
+        raise ValueError(f"Missing required columns in train data: {missing}")
+    train[date_col + "_str"] = train[date_col].astype(str)
+    train[date_col] = pd.to_datetime(train[date_col])
+    train["DOW"] = train[date_col].dt.weekday
+    train["series_id"] = train[series_cols[0]].astype(str) + "_" + train[series_cols[1]].astype(str)
+    train = train.sort_values(["series_id", date_col]).reset_index(drop=True)
+    return train
+
+
+@dataclass
+class HurdleForecastModel:
+    cfg: Config
+    train: pd.DataFrame
+    train_pos: np.ndarray
+
+    @classmethod
+    def from_config(cls, cfg: Config) -> "HurdleForecastModel":
+        train = _prepare_train(cfg)
+        train_pos = train.loc[train[cfg.target_col] > 0, cfg.target_col].values
+        return cls(cfg=cfg, train=train, train_pos=train_pos)
+
+    def save(self, path: str) -> None:
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+        with open(path, "wb") as f:
+            pickle.dump(self, f)
+
+    @staticmethod
+    def load(path: str) -> "HurdleForecastModel":
+        with open(path, "rb") as f:
+            return pickle.load(f)
+
+    def predict_dir(self, test_dir: str, out_dir: str, sample_submission: Optional[str] = None) -> None:
+        """Run forecasts for all TEST_*.csv in `test_dir` and write outputs."""
+        os.makedirs(out_dir, exist_ok=True)
+        series_cols = self.cfg.series_cols
+        date_col = self.cfg.date_col
+        target_col = self.cfg.target_col
+
+        for fname in sorted(os.listdir(test_dir)):
+            if not (fname.startswith("TEST_") and fname.endswith(".csv")):
+                continue
+            path = os.path.join(test_dir, fname)
+            df_test = pd.read_csv(path)
+            missing = [c for c in [*series_cols, date_col] if c not in df_test.columns]
+            if missing:
+                raise ValueError(f"Missing required columns in test data {fname}: {missing}")
+            df_test[date_col + "_str"] = df_test[date_col].astype(str)
+            df_test[date_col] = pd.to_datetime(df_test[date_col])
+            df_test["DOW"] = df_test[date_col].dt.weekday
+            df_test["series_id"] = df_test[series_cols[0]].astype(str) + "_" + df_test[series_cols[1]].astype(str)
+            df_test = df_test.sort_values(["series_id", date_col]).reset_index(drop=True)
+
+            test_dates = future_dates(df_test, date_col)
+            cutoff_date = min(test_dates)
+            train_cut = cutoff_train(self.train, cutoff_date)
+
+            preds = []
+
+            if self.cfg.classifier_kind == "logit":
+                fut_cal = df_test[[date_col, "DOW", "series_id"]].copy()
+                P_all = logistic_global_calendar(
+                    train_cut=train_cut,
+                    future_calendar=fut_cal,
+                    lr=self.cfg.logit_lr,
+                    epochs=self.cfg.logit_epochs,
+                    l2=self.cfg.logit_l2,
+                    batch_size=self.cfg.logit_batch_size,
+                )
+                df_test = df_test.copy()
+                df_test["P_nonzero"] = P_all
+
+            for sid, tdf in df_test.groupby("series_id"):
+                fut_dates = tdf[date_col].tolist()
+                fut_dows = tdf["DOW"].tolist()
+
+                if self.cfg.classifier_kind == "beta":
+                    P = beta_smooth_probs(
+                        train_cut=train_cut,
+                        series_id=sid,
+                        future_dows=fut_dows,
+                        window_weeks=self.cfg.dow_window_weeks,
+                        alpha=self.cfg.beta_alpha,
+                        beta=self.cfg.beta_beta,
+                        date_col=date_col,
+                        target_col=target_col,
+                    )
+                else:
+                    P = tdf["P_nonzero"].values
+
+                mu = forecast_intensity(
+                    train_cut=train_cut,
+                    series_id=sid,
+                    future_dates=fut_dates,
+                    m=self.cfg.seasonal_m,
+                    grid=self.cfg.sarima_grid,
+                    val_weeks=self.cfg.val_weeks,
+                    fallback=self.cfg.fallback,
+                    target_col=target_col,
+                )
+
+                yhat = combine_expectation(P, mu, self.cfg.cap_quantile, train_positive=self.train_pos)
+
+                out = tdf[[*series_cols, date_col + "_str"]].copy()
+                out.rename(columns={date_col + "_str": date_col}, inplace=True)
+                out["예측값"] = yhat
+                preds.append(out)
+
+            pred_df = pd.concat(preds, axis=0, ignore_index=True)
+            out_path = os.path.join(out_dir, f"pred_{fname}")
+            pred_df.to_csv(out_path, index=False, encoding="utf-8-sig")
+
+        if sample_submission is not None:
+            skel = pd.read_csv(sample_submission)
+            all_preds = []
+            for p in sorted(os.listdir(out_dir)):
+                if p.startswith("pred_TEST_") and p.endswith(".csv"):
+                    all_preds.append(pd.read_csv(os.path.join(out_dir, p)))
+            if all_preds:
+                pred_all = pd.concat(all_preds, ignore_index=True)
+                filled = fill_submission_skeleton(
+                    skel,
+                    pred_all,
+                    date_col=date_col,
+                    series_cols=series_cols,
+                    value_col="예측값",
+                )
+                filled_path = os.path.join(out_dir, "submission_filled.csv")
+                filled.to_csv(filled_path, index=False, encoding="utf-8-sig")

--- a/train.py
+++ b/train.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+import argparse
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "src"))
+
+from hurdle_forecast.config import Config
+from hurdle_forecast.model import HurdleForecastModel
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Train hurdle forecast model and serialize to pickle.")
+    ap.add_argument("--train", dest="train_csv", required=True, help="Path to train.csv")
+    ap.add_argument("--model_out", default="models/model.pkl", help="Output path for pickled model")
+    ap.add_argument("--classifier", choices=["beta", "logit"], default="beta")
+    ap.add_argument("--sarima_grid", choices=["full", "small"], default="full")
+    ap.add_argument("--fallback", choices=["ets", "snaive"], default="ets")
+    ap.add_argument("--cap", type=float, default=0.99, help="Quantile cap (set <=0 or >1 to disable)")
+    args = ap.parse_args()
+
+    cfg = Config(
+        train_csv=args.train_csv,
+        test_dir="",
+        out_dir="",
+        sample_submission=None,
+        classifier_kind=args.classifier,
+        sarima_grid=args.sarima_grid,
+        fallback=args.fallback,
+        cap_quantile=(args.cap if 0.0 < args.cap < 1.0 else None),
+    )
+
+    model = HurdleForecastModel.from_config(cfg)
+    model.save(args.model_out)
+    print(f"Model saved to {args.model_out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `HurdleForecastModel` class to encapsulate training data and prediction logic
- create `train.py` to build and serialize models with argparse interface
- create `predict.py` to load serialized models and generate forecasts

## Testing
- `python -m pytest`
- `python train.py --help`
- `python predict.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68b6d380087c832887659eb7134da6a7