### PR TITLE
docs: add Colab walkthrough and split run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,33 @@ hurdle-forecast \
   --sample_submission path/to/sample_submission.csv  # optional
 ```
 
+**Colab example**
+
+The following cells show a minimal end-to-end run inside Google Colab:
+
+```python
+# 1. clone repository and move into it
+!git clone https://github.com/<your-user>/hurdle-forecast.git
+%cd hurdle-forecast
+
+# 2. install dependencies
+!python dependency.py
+
+# 3. train model
+!python train.py --train data/train/train.csv --model_out models/model.pkl
+
+# 4. predict
+!python predict.py --model models/model.pkl --test_dir data/test --out_dir outputs
+```
+
+**Key parameters**
+
+- `--train`: path to the training CSV (e.g. `data/train/train.csv`).
+- `--model_out`: where to store the trained model (default `models/model.pkl`).
+- `--test_dir`: directory with `TEST_*.csv` files (e.g. `data/test`).
+- `--out_dir`: directory to write predictions (e.g. `outputs`).
+- `--sample_submission`: optional CSV skeleton for competition submissions.
+
 **Expectations / Columns**
 - Train csv must include: `영업일자`, `영업장명`, `메뉴명`, `매출수량`.
 - Test csv must include: `영업일자`, `영업장명`, `메뉴명` (and any other columns are preserved).

--- a/run.sh
+++ b/run.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 python -m venv .venv
 source .venv/bin/activate
-pip install -e .
+python dependency.py
 python -m pip install torch --index-url https://download.pytorch.org/whl/cpu || true
-hurdle-forecast --train data/train/train.csv --test_dir data/test --out_dir outputs
+python train.py --train data/train/train.csv --model_out models/model.pkl
+python predict.py --model models/model.pkl --test_dir data/test --out_dir outputs


### PR DESCRIPTION
## Summary
- add Google Colab usage example with training and prediction steps
- revise run.sh to install dependencies, train, then predict separately

## Testing
- `./run.sh` *(fails: Could not find a version that satisfies the requirement numpy>=1.24)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d68df60c8328aedff1b0c900862e