### PR TITLE
Handle joined store-menu column during data loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ The following cells show a minimal end-to-end run inside Google Colab:
 - `--sample_submission`: optional CSV skeleton for competition submissions.
 
 **Expectations / Columns**
-- Train csv must include: `영업일자`, `영업장명`, `메뉴명`, `매출수량`.
-- Test csv must include: `영업일자`, `영업장명`, `메뉴명` (and any other columns are preserved).
+- Train csv must include: `영업일자`, `매출수량`, and either separate `영업장명`/`메뉴명` columns or a combined `영업장명_메뉴명` column which will be split.
+- Test csv must include: `영업일자` and either separate `영업장명`/`메뉴명` columns or `영업장명_메뉴명` (and any other columns are preserved).
 - Dates are kept **as strings** in the final submission; internal processing uses a parsed datetime index with no leakage.
 - Each `TEST_*.csv` is predicted **independently** (no cross-file leakage) and a matching output file is written to `outputs/`.
 - If a `--sample_submission` is given, we **only fill the values** in that skeleton and never touch column names or date string formats.

--- a/src/hurdle_forecast/config.py
+++ b/src/hurdle_forecast/config.py
@@ -9,6 +9,7 @@ class Config:
     sample_submission: Optional[str] = None
 
     horizon: int = 7
+    # expects separate columns, but a joined `영업장명_메뉴명` will be split automatically
     series_cols: tuple = ("영업장명", "메뉴명")
     date_col: str = "영업일자"
     target_col: str = "매출수량"

--- a/src/hurdle_forecast/model.py
+++ b/src/hurdle_forecast/model.py
@@ -7,7 +7,7 @@ import pandas as pd
 import numpy as np
 
 from .config import Config
-from .data import cutoff_train, future_dates
+from .data import cutoff_train, future_dates, maybe_split_series
 from .classifier import beta_smooth_probs, logistic_global_calendar
 from .intensity import forecast_intensity
 from .combine import combine_expectation, fill_submission_skeleton
@@ -19,6 +19,7 @@ def _prepare_train(cfg: Config) -> pd.DataFrame:
     series_cols = cfg.series_cols
     date_col = cfg.date_col
     target_col = cfg.target_col
+    maybe_split_series(train, series_cols)
     missing = [c for c in [*series_cols, date_col, target_col] if c not in train.columns]
     if missing:
         raise ValueError(f"Missing required columns in train data: {missing}")
@@ -64,6 +65,7 @@ class HurdleForecastModel:
                 continue
             path = os.path.join(test_dir, fname)
             df_test = pd.read_csv(path)
+            maybe_split_series(df_test, series_cols)
             missing = [c for c in [*series_cols, date_col] if c not in df_test.columns]
             if missing:
                 raise ValueError(f"Missing required columns in test data {fname}: {missing}")


### PR DESCRIPTION
## Summary
- Support datasets that provide a combined `영업장명_메뉴명` column by splitting it into `영업장명` and `메뉴명`
- Apply the split in training and prediction flows and document the requirement

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6db6945008328b0d78f662a4f624f