### PR TITLE
Handle NaN outputs in intensity forecasts

### DIFF
--- a/src/hurdle_forecast/intensity.py
+++ b/src/hurdle_forecast/intensity.py
@@ -132,5 +132,6 @@ def forecast_intensity(
         fc = res.get_forecast(steps=len(future_dates), exog=exog_future)
         mu_log = fc.predicted_mean
     mu = np.expm1(mu_log.values)
+    mu = np.nan_to_num(mu, nan=0.0)
     mu = np.maximum(mu, 0.0)  # clip negatives
     return mu

--- a/tests/test_intensity_nan.py
+++ b/tests/test_intensity_nan.py
@@ -1,0 +1,44 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from hurdle_forecast import intensity
+
+
+def test_forecast_intensity_handles_nan_predictions(monkeypatch):
+    """Even if the underlying model returns NaNs, the forecast should be finite.
+    This scenario can occur when the time series contains only zeros."""
+    dates = pd.date_range('2023-01-01', periods=20, freq='D')
+    train = pd.DataFrame({
+        'series_id': 'A',
+        '영업일자': dates,
+        '매출수량': 0,
+    })
+    future_dates = [pd.Timestamp('2023-01-21') + pd.Timedelta(days=i) for i in range(3)]
+
+    # Pretend we have enough non-zero observations to avoid early fallback
+    original_notna = pd.Series.notna
+
+    def fake_notna(self):
+        if self.name == '매출수량':
+            return pd.Series([True] * len(self), index=self.index)
+        return original_notna(self)
+
+    monkeypatch.setattr(pd.Series, "notna", fake_notna, raising=False)
+
+    class DummyRes:
+        params = np.array([0.0])
+        aic = 0.0
+
+        def get_forecast(self, steps, exog=None):
+            class DummyForecast:
+                def __init__(self, steps):
+                    self.predicted_mean = pd.Series([np.nan] * steps)
+
+            return DummyForecast(steps)
+
+    monkeypatch.setattr(intensity, "_fit_sarimax", lambda *args, **kwargs: DummyRes())
+    monkeypatch.setattr(intensity, "_candidate_orders", lambda grid='full': [(0, 0, 0, 0, 0, 0)])
+
+    mu = intensity.forecast_intensity(train, 'A', future_dates)
+    assert np.all(np.isfinite(mu))


### PR DESCRIPTION
## Summary
- prevent NaN values in intensity forecasts by replacing NaNs with zero before clipping
- add regression test ensuring forecasts are finite even when underlying model returns NaNs

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6e839e10c8328b350dafdcd86ddcf