### PR TITLE
Clip log intensity to avoid overflow

### DIFF
--- a/src/hurdle_forecast/intensity.py
+++ b/src/hurdle_forecast/intensity.py
@@ -131,7 +131,8 @@ def forecast_intensity(
         warnings.simplefilter("ignore")
         fc = res.get_forecast(steps=len(future_dates), exog=exog_future)
         mu_log = fc.predicted_mean
-    mu = np.expm1(mu_log.values)
+    mu_log = np.clip(mu_log.values, -700, 700)
+    mu = np.expm1(mu_log)
     mu = np.nan_to_num(mu, nan=0.0)
     mu = np.maximum(mu, 0.0)  # clip negatives
     return mu


### PR DESCRIPTION
## Summary
- Clip predicted log intensities to [-700, 700] before exponentiation to avoid overflow in `np.expm1`

## Testing
- `PYTHONPATH=src pytest -q`
- `PYTHONPATH=src python - <<'PY'
import pandas as pd
from hurdle_forecast.data import maybe_split_series
from hurdle_forecast.intensity import forecast_intensity
train = pd.read_csv('data/train/train.csv')
maybe_split_series(train, ("영업장명", "메뉴명"))
train['영업일자'] = pd.to_datetime(train['영업일자'])
train['series_id'] = train['영업장명'].astype(str)+'_'+train['메뉴명'].astype(str)
cutoff = train
sid = train['series_id'].iloc[0]
future_dates = pd.date_range(train['영업일자'].max() + pd.Timedelta(days=1), periods=7, freq='D')
mu = forecast_intensity(cutoff, sid, list(future_dates), m=7, grid='small', val_weeks=1, fallback='ets', target_col='매출수량')
print(mu)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b6f68fcdf88328be455762b7d257c2