### PR TITLE
Align prediction outputs with submission skeleton

### DIFF
--- a/src/hurdle_forecast/model.py
+++ b/src/hurdle_forecast/model.py
@@ -194,9 +194,12 @@ class HurdleForecastModel:
                     date_col: [d.strftime("%Y-%m-%d") for d in fut_dates],
                     "예측값": yhat,
                 })
+                # ensure consistent column order for downstream merging
+                out = out[[*series_cols, date_col, "예측값"]]
                 preds.append(out)
 
             pred_df = pd.concat(preds, axis=0, ignore_index=True)
+            pred_df = pred_df[[*series_cols, date_col, "예측값"]]
             out_path = os.path.join(out_dir, f"pred_{fname}")
             pred_df.to_csv(out_path, index=False, encoding="utf-8-sig")
 
@@ -208,6 +211,7 @@ class HurdleForecastModel:
                     all_preds.append(pd.read_csv(os.path.join(out_dir, p)))
             if all_preds:
                 pred_all = pd.concat(all_preds, ignore_index=True)
+                pred_all = pred_all[[*series_cols, date_col, "예측값"]]
                 filled = fill_submission_skeleton(
                     skel,
                     pred_all,

--- a/src/hurdle_forecast/pipeline.py
+++ b/src/hurdle_forecast/pipeline.py
@@ -125,9 +125,12 @@ def predict_with_models(cfg: Config, models: Dict[str, Dict]):
             out = smod["out"].copy()
             yhat = combine_expectation(P, mu, cfg.cap_quantile, train_positive=train_pos)
             out["예측값"] = yhat
+            # enforce column ordering for downstream compatibility
+            out = out[[*cfg.series_cols, cfg.date_col, "예측값"]]
             preds.append(out)
 
         pred_df = pd.concat(preds, axis=0, ignore_index=True)
+        pred_df = pred_df[[*cfg.series_cols, cfg.date_col, "예측값"]]
         out_path = os.path.join(cfg.out_dir, f"pred_{fname}")
         pred_df.to_csv(out_path, index=False, encoding="utf-8-sig")
 
@@ -139,6 +142,7 @@ def predict_with_models(cfg: Config, models: Dict[str, Dict]):
                 all_preds.append(pd.read_csv(os.path.join(cfg.out_dir, p)))
         if all_preds:
             pred_all = pd.concat(all_preds, ignore_index=True)
+            pred_all = pred_all[[*cfg.series_cols, cfg.date_col, "예측값"]]
             filled = fill_submission_skeleton(
                 skel,
                 pred_all,


### PR DESCRIPTION
## Summary
- Ensure prediction DataFrames use column order `[series_cols, date_col, '예측값']` for compatibility
- Preserve `sample_submission.csv` column names when filling the submission skeleton

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7a618cf808328818c69c2d73a19e1