### PR TITLE
Use full training data for logistic classifier

### DIFF
--- a/src/hurdle_forecast/model.py
+++ b/src/hurdle_forecast/model.py
@@ -135,7 +135,7 @@ class HurdleForecastModel:
             if self.cfg.classifier_kind == "logit":
                 fut_cal = pd.DataFrame(future_rows)
                 P_all = logistic_global_calendar(
-                    train_cut=train_cut,
+                    train_cut=train_full,
                     future_calendar=fut_cal,
                     lr=self.cfg.logit_lr,
                     epochs=self.cfg.logit_epochs,


### PR DESCRIPTION
## Summary
- pass full training dataset to `logistic_global_calendar` within `HurdleForecastModel.predict_dir`

## Testing
- `PYTHONPATH=src python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7b3d2be4c8328b1ed853960bc4a94