### PR TITLE
Handle tuple keys in wide fill_submission_skeleton

### DIFF
--- a/src/hurdle_forecast/combine.py
+++ b/src/hurdle_forecast/combine.py
@@ -115,7 +115,9 @@ def fill_submission_skeleton(
     if set(series_cols).isdisjoint(skel.columns):
         pred_df = pred_df.copy()
         if len(series_cols) > 1:
-            pred_df["series_id"] = pred_df[series_cols].astype(str).agg("_".join, axis=1)
+            pred_df["series_id"] = (
+                pred_df[list(series_cols)].astype(str).agg("_".join, axis=1)
+            )
         else:
             pred_df["series_id"] = pred_df[series_cols[0]].astype(str)
         wide = (

--- a/tests/test_fill_submission_skeleton.py
+++ b/tests/test_fill_submission_skeleton.py
@@ -1,0 +1,30 @@
+import pandas as pd
+from hurdle_forecast.combine import fill_submission_skeleton
+
+def test_fill_submission_skeleton_wide_two_keys():
+    skel = pd.DataFrame(
+        {
+            "date": pd.date_range("2020-01-01", periods=2),
+            "0_0": [None, None],
+            "0_1": [None, None],
+        }
+    )
+    pred_df = pd.DataFrame(
+        {
+            "date": pd.date_range("2020-01-01", periods=2).repeat(2),
+            "store": [0, 0, 0, 0],
+            "item": [0, 1, 0, 1],
+            "pred": [1, 2, 3, 4],
+        }
+    )
+    out = fill_submission_skeleton(
+        skel,
+        pred_df,
+        date_col="date",
+        series_cols=("store", "item"),
+        value_col="pred",
+    )
+    assert out.loc[0, "0_0"] == 1
+    assert out.loc[0, "0_1"] == 2
+    assert out.loc[1, "0_0"] == 3
+    assert out.loc[1, "0_1"] == 4


### PR DESCRIPTION
## Summary
- Fix wide-format submission filling to cast series column tuple to list to avoid KeyError
- Add regression test ensuring multiple key wide-format joins work

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7bc90ed008328a16a0828768a42d6