### PR TITLE
Add series-DOW priors and calibration to logistic classifier

### DIFF
--- a/src/hurdle_forecast/config.py
+++ b/src/hurdle_forecast/config.py
@@ -28,6 +28,8 @@ class Config:
     logit_epochs: int = 200
     logit_l2: float = 1e-4
     logit_batch_size: int = 4096
+    calib_lambda: float = 0.8
+    class_weight: bool = True
 
     # Intensity settings
     seasonal_m: int = 7

--- a/src/hurdle_forecast/model.py
+++ b/src/hurdle_forecast/model.py
@@ -164,6 +164,11 @@ class HurdleForecastModel:
                     epochs=self.cfg.logit_epochs,
                     l2=self.cfg.logit_l2,
                     batch_size=self.cfg.logit_batch_size,
+                    window_weeks=self.cfg.dow_window_weeks,
+                    alpha=self.cfg.beta_alpha,
+                    beta=self.cfg.beta_beta,
+                    calib_lambda=self.cfg.calib_lambda,
+                    class_weight=self.cfg.class_weight,
                 )
                 P_batch = []
                 for i in range(len(series_ids)):

--- a/src/hurdle_forecast/pipeline.py
+++ b/src/hurdle_forecast/pipeline.py
@@ -64,6 +64,11 @@ def train_models(cfg: Config) -> Dict[str, Dict]:
                 epochs=cfg.logit_epochs,
                 l2=cfg.logit_l2,
                 batch_size=cfg.logit_batch_size,
+                window_weeks=cfg.dow_window_weeks,
+                alpha=cfg.beta_alpha,
+                beta=cfg.beta_beta,
+                calib_lambda=cfg.calib_lambda,
+                class_weight=cfg.class_weight,
             )
             fut_cal = fut_cal.copy()
             fut_cal["P_nonzero"] = to_numpy(P_all)


### PR DESCRIPTION
## Summary
- Implement beta-smoothed series/DOW lookup and use logits as features for logistic classifier
- Add class weighting and calibration smoothing to logistic predictions
- Expose calibration and class-weight options in configuration and wire through pipeline and model

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7cd292aa8832884e3a5a16ef60cd4