### PR TITLE
Refine SARIMA order selection and fix seasonality configuration

### DIFF
--- a/src/hurdle_forecast/config.py
+++ b/src/hurdle_forecast/config.py
@@ -32,7 +32,6 @@ class Config:
     class_weight: bool = True
 
     # Intensity settings
-    seasonal_m: int = 7
     sarima_grid: Literal["full", "small"] = "full"
     val_weeks: int = 4
     fallback: Literal["ets", "snaive"] = "ets"

--- a/src/hurdle_forecast/model.py
+++ b/src/hurdle_forecast/model.py
@@ -196,7 +196,6 @@ class HurdleForecastModel:
                     train_cut=train_full,
                     series_id=series_ids,
                     future_dates=fut_dates_list,
-                    m=self.cfg.seasonal_m,
                     grid=self.cfg.sarima_grid,
                     val_weeks=self.cfg.val_weeks,
                     fallback=self.cfg.fallback,

--- a/src/hurdle_forecast/pipeline.py
+++ b/src/hurdle_forecast/pipeline.py
@@ -136,7 +136,6 @@ def train_models(cfg: Config) -> Dict[str, Dict]:
                 train_cut=train_full,
                 series_id=sid,
                 future_dates=fut_dates,
-                m=cfg.seasonal_m,
                 grid=cfg.sarima_grid,
                 val_weeks=cfg.val_weeks,
                 fallback=cfg.fallback,

--- a/tests/test_intensity_inf.py
+++ b/tests/test_intensity_inf.py
@@ -29,6 +29,7 @@ def test_forecast_intensity_handles_inf_from_expm1(monkeypatch):
     class DummyRes:
         params = np.array([0.0])
         aic = 0.0
+        mle_retvals = {"converged": True}
 
         def get_forecast(self, steps, exog=None):
             class DummyForecast:
@@ -38,9 +39,7 @@ def test_forecast_intensity_handles_inf_from_expm1(monkeypatch):
             return DummyForecast(steps)
 
     monkeypatch.setattr(intensity, "_fit_sarimax", lambda *args, **kwargs: DummyRes())
-    monkeypatch.setattr(
-        intensity, "_candidate_orders", lambda grid="full": [(0, 0, 0, 0, 0, 0)]
-    )
+    monkeypatch.setattr(intensity, "_candidate_orders", lambda: [(0, 0, 0, 0, 0, 0)])
 
     # Force np.expm1 to overflow
     monkeypatch.setattr(intensity.np, "expm1", lambda x: np.full_like(x, np.inf))

--- a/tests/test_intensity_nan.py
+++ b/tests/test_intensity_nan.py
@@ -29,6 +29,7 @@ def test_forecast_intensity_handles_nan_predictions(monkeypatch):
     class DummyRes:
         params = np.array([0.0])
         aic = 0.0
+        mle_retvals = {"converged": True}
 
         def get_forecast(self, steps, exog=None):
             class DummyForecast:
@@ -38,7 +39,7 @@ def test_forecast_intensity_handles_nan_predictions(monkeypatch):
             return DummyForecast(steps)
 
     monkeypatch.setattr(intensity, "_fit_sarimax", lambda *args, **kwargs: DummyRes())
-    monkeypatch.setattr(intensity, "_candidate_orders", lambda grid='full': [(0, 0, 0, 0, 0, 0)])
+    monkeypatch.setattr(intensity, "_candidate_orders", lambda: [(0, 0, 0, 0, 0, 0)])
 
     mu = intensity.forecast_intensity(train, 'A', future_dates)
     assert np.all(np.isfinite(mu))


### PR DESCRIPTION
## Summary
- hard-code SARIMA candidate orders with simple {0,1} combinations and evaluate using validation RMSE plus AICc
- remove seasonal_m override and assume weekly seasonality
- update pipeline and tests for new interfaces

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7cfaced1c83289b099fbdb3fda41c