### PR TITLE
Handle exogenous feature column mismatches

### DIFF
--- a/src/hurdle_forecast/intensity.py
+++ b/src/hurdle_forecast/intensity.py
@@ -140,6 +140,12 @@ def _forecast_intensity_single(
 
     exog = _make_exog_dow(y.index)
     exog_future = _make_exog_dow(pd.DatetimeIndex(future_dates))
+    if list(exog.columns) != list(exog_future.columns):
+        logging.getLogger(__name__).warning(
+            "Exogenous feature columns misaligned; reindexing future exog",
+        )
+        exog_future = exog_future.reindex(columns=exog.columns, fill_value=0)
+    assert list(exog.columns) == list(exog_future.columns)
 
     best: Dict[str, Union[float, Tuple[int, int, int], Tuple[int, int, int]]] = {
         "score": np.inf,

--- a/tests/test_intensity_exog_alignment.py
+++ b/tests/test_intensity_exog_alignment.py
@@ -1,0 +1,45 @@
+import numpy as np
+import pandas as pd
+import logging
+
+from hurdle_forecast import intensity
+
+
+def test_forecast_intensity_aligns_exog(monkeypatch, caplog):
+    dates = pd.date_range('2023-01-01', periods=20, freq='D')
+    train = pd.DataFrame({
+        'series_id': 'A',
+        '영업일자': dates,
+        '매출수량': np.arange(1, 21),
+    })
+    future_dates = [pd.Timestamp('2023-01-21'), pd.Timestamp('2023-01-22')]
+
+    def fake_make_exog_dow(idx):
+        if len(idx) > 2:
+            return pd.DataFrame({'a': np.ones(len(idx)), 'b': np.ones(len(idx))}, index=idx)
+        return pd.DataFrame({'b': np.ones(len(idx)), 'c': np.ones(len(idx))}, index=idx)
+
+    monkeypatch.setattr(intensity, '_make_exog_dow', fake_make_exog_dow)
+    monkeypatch.setattr(intensity, '_candidate_orders', lambda: [(0, 0, 0, 0, 0, 0)])
+
+    class DummyRes:
+        params = np.array([0.0])
+        aic = 0.0
+        mle_retvals = {'converged': True}
+
+        def get_forecast(self, steps, exog=None):
+            self.exog = exog
+            class DummyForecast:
+                def __init__(self, steps):
+                    self.predicted_mean = pd.Series([0.0] * steps)
+            return DummyForecast(steps)
+
+    dummy_res = DummyRes()
+    monkeypatch.setattr(intensity, '_fit_sarimax', lambda *args, **kwargs: dummy_res)
+
+    with caplog.at_level(logging.WARNING):
+        intensity._forecast_intensity_single(train, 'A', future_dates)
+
+    assert list(dummy_res.exog.columns) == ['a', 'b']
+    assert (dummy_res.exog['a'] == 0).all()
+    assert 'Exogenous feature columns misaligned' in caplog.text


### PR DESCRIPTION
## Summary
- Ensure `_forecast_intensity_single` reindexes future exogenous features when column order differs and log a warning
- Add regression test covering exogenous column alignment fallback

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8f384e27c83289d9ac6b553191587