### PR TITLE
Remove SARIMAX intercept and test weekend dummies

### DIFF
--- a/src/hurdle_forecast/intensity.py
+++ b/src/hurdle_forecast/intensity.py
@@ -78,6 +78,7 @@ def _fit_sarimax(
             order=order,
             seasonal_order=(*seasonal_order, m),
             exog=exog,
+            trend="n",
             enforce_stationarity=True,
             enforce_invertibility=True,
             initialization="approximate_diffuse",

--- a/tests/test_weekend_dummy_positive.py
+++ b/tests/test_weekend_dummy_positive.py
@@ -1,0 +1,15 @@
+import numpy as np
+import pandas as pd
+
+from hurdle_forecast import intensity
+
+
+def test_weekend_dummy_coefficients_positive():
+    idx = pd.date_range("2023-01-01", periods=70, freq="D")
+    y_log = pd.Series(np.where(idx.weekday >= 5, 1.0, 0.0), index=idx)
+    exog = intensity._make_exog_dow(idx)
+    res = intensity._fit_sarimax(y_log, exog, (0, 0, 0), (0, 0, 0), 7)
+    params = res.params
+    assert params["dow_5"] > 0
+    assert params["dow_6"] > 0
+


### PR DESCRIPTION
## Summary
- Remove intercept term from SARIMAX model to rely solely on exogenous features
- Add unit test ensuring weekend dummy coefficients are positive

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8f496947883289062a48d3c01858d