### PR TITLE
Add configurable logging to prediction script

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import argparse
+import logging
 import os
 import sys
 
@@ -14,10 +15,16 @@ def main() -> None:
     ap.add_argument("--test_dir", required=True, help="Directory containing TEST_*.csv files")
     ap.add_argument("--out_dir", required=True, help="Directory to write predictions")
     ap.add_argument("--sample_submission", default=None, help="Optional sample submission to fill")
+    ap.add_argument("--log-level", default="INFO", help="Logging level")
     args = ap.parse_args()
+    logging.basicConfig(level=args.log_level.upper(), format="%(asctime)s %(levelname)s %(message)s")
+    logger = logging.getLogger(__name__)
 
+    logger.info("Loading model from %s", args.model)
     model = HurdleForecastModel.load(args.model)
+    logger.info("Running predictions for %s", args.test_dir)
     model.predict_dir(args.test_dir, args.out_dir, sample_submission=args.sample_submission)
+    logger.info("Predictions written to %s", args.out_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `--log-level` argument to prediction script
- configure logging and emit messages around model load and prediction

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hurdle_forecast')*

------
https://chatgpt.com/codex/tasks/task_e_68b8f921df088328bba30e66a4f1e200