### PR TITLE
Log progress for series forecasts

### DIFF
--- a/src/hurdle_forecast/model.py
+++ b/src/hurdle_forecast/model.py
@@ -145,8 +145,10 @@ class HurdleForecastModel:
             fut_dates_list: List[List[pd.Timestamp]] = []
             fut_dows_list: List[List[int]] = []
             future_rows: List[Dict[str, object]] = []
+            log_every = max(1, len(groups) // 20)
             for j, (sid, tdf) in enumerate(groups, 1):
-                logging.debug("  Series %s (%d/%d)", sid, j, len(groups))
+                if j % log_every == 0 or j == len(groups):
+                    logging.info("  Series %s (%d/%d)", sid, j, len(groups))
                 last_date = tdf[date_col].max()
                 fut_dates = [
                     last_date + pd.Timedelta(days=i)


### PR DESCRIPTION
## Summary
- log series processing progress at info level
- throttle logging to avoid excessive output on large batches

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hurdle_forecast')*

------
https://chatgpt.com/codex/tasks/task_e_68b90b15be148328857d9ebba37f7fe6